### PR TITLE
overridable method for AbstractBinaryFullCircuitOperator - will be us…

### DIFF
--- a/src/main/java/com/scriptbasic/executors/operators/AbstractBinaryFullCircuitOperator.java
+++ b/src/main/java/com/scriptbasic/executors/operators/AbstractBinaryFullCircuitOperator.java
@@ -15,14 +15,38 @@ import com.scriptbasic.spi.RightValue;
  */
 public abstract class AbstractBinaryFullCircuitOperator extends
         AbstractBinaryOperator {
+    
+    /**
+     * Function used to evaluate left operand.
+     * Override this function if custom evaluation is needed.
+     * 
+     * @param interpreter 
+     * @return Return evaluated operand
+     * @throws ScriptBasicException
+     */
+    protected RightValue getLeftOperandEvaluated(final Interpreter interpreter) throws ScriptBasicException {
+        return getLeftOperand().evaluate(interpreter);
+    }
+    
+    /**
+     * Function used to evaluate right operand.
+     * Override this function if custom evaluation is needed.
+     * 
+     * @param interpreter 
+     * @return Return evaluated operand
+     * @throws ScriptBasicException
+     */
+    protected RightValue getRightOperandEvaluated(final Interpreter interpreter) throws ScriptBasicException {
+        return getRightOperand().evaluate(interpreter);
+    }
 
     protected abstract RightValue evaluateOn(RightValue leftOperand,
                                              RightValue rightOperand) throws ScriptBasicException;
 
     @Override
     public final RightValue evaluate(final Interpreter interpreter) throws ScriptBasicException {
-        return evaluateOn(getLeftOperand().evaluate(interpreter), getRightOperand()
-                .evaluate(interpreter));
+        return evaluateOn(getLeftOperandEvaluated(interpreter), 
+                          getRightOperandEvaluated(interpreter));
     }
 
 }

--- a/src/main/java/com/scriptbasic/executors/operators/AbstractBinaryFullCircuitOperator.java
+++ b/src/main/java/com/scriptbasic/executors/operators/AbstractBinaryFullCircuitOperator.java
@@ -20,9 +20,9 @@ public abstract class AbstractBinaryFullCircuitOperator extends
      * Function used to evaluate left operand.
      * Override this function if custom evaluation is needed.
      * 
-     * @param interpreter 
-     * @return Return evaluated operand
-     * @throws ScriptBasicException
+     * @param interpreter current interpreter
+     * @return evaluated operand
+     * @throws ScriptBasicException when the evaluation of the operand cannot be performed w/o error
      */
     protected RightValue getLeftOperandEvaluated(final Interpreter interpreter) throws ScriptBasicException {
         return getLeftOperand().evaluate(interpreter);
@@ -32,9 +32,9 @@ public abstract class AbstractBinaryFullCircuitOperator extends
      * Function used to evaluate right operand.
      * Override this function if custom evaluation is needed.
      * 
-     * @param interpreter 
-     * @return Return evaluated operand
-     * @throws ScriptBasicException
+     * @param interpreter current interpreter
+     * @return evaluated operand
+     * @throws ScriptBasicException  when the evaluation of the operand cannot be performed w/o error
      */
     protected RightValue getRightOperandEvaluated(final Interpreter interpreter) throws ScriptBasicException {
         return getRightOperand().evaluate(interpreter);


### PR DESCRIPTION
overridable method for AbstractBinaryFullCircuitOperator - will be used in select/case implementation for operator 'to'. We will need to implement customized EqualOperator with one operator already evaluated.