### PR TITLE
Rename consumeEndOfLine to consumeEndOfStatement and allow to use colon as a statement separator

### DIFF
--- a/src/main/java/com/scriptbasic/interfaces/LexicalElement.java
+++ b/src/main/java/com/scriptbasic/interfaces/LexicalElement.java
@@ -79,5 +79,12 @@ public interface LexicalElement extends SourceLocationBound {
      */
     Boolean isSymbol(String lexeme);
 
+    /**
+     * Return true if the lexical element is colon 
+     * 
+     * @return true if the lexical element is colon
+     */
+    Boolean isStatementSeparator();
+
     Boolean isLineTerminator();
 }

--- a/src/main/java/com/scriptbasic/lexer/BasicLexicalElement.java
+++ b/src/main/java/com/scriptbasic/lexer/BasicLexicalElement.java
@@ -179,4 +179,10 @@ public class BasicLexicalElement extends AbstractLexicalElement {
                 && CharUtils.isNewLine(getLexeme().codePointAt(0));
     }
 
+    @Override
+    public Boolean isStatementSeparator() {
+        return getType() == TYPE_SYMBOL && getLexeme().length() == 1
+                && getLexeme().codePointAt(0)==':';
+    }
+
 }

--- a/src/main/java/com/scriptbasic/lexer/BasicLexicalElement.java
+++ b/src/main/java/com/scriptbasic/lexer/BasicLexicalElement.java
@@ -182,7 +182,7 @@ public class BasicLexicalElement extends AbstractLexicalElement {
     @Override
     public Boolean isStatementSeparator() {
         return getType() == TYPE_SYMBOL && getLexeme().length() == 1
-                && getLexeme().codePointAt(0)==':';
+                && getLexeme().codePointAt(0) == ':';
     }
 
 }

--- a/src/main/java/com/scriptbasic/syntax/commands/AbstractCommandAnalyzer.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/AbstractCommandAnalyzer.java
@@ -93,17 +93,16 @@ public abstract class AbstractCommandAnalyzer extends AbstractAnalyzer<Command>
     }
 
     /**
-     * Checks that there are no extra characters on a program line when the line
-     * analyzer thinks that it has finished analyzing the line. If there are
+     * Checks that there are no extra characters when the line analyzer 
+     * expects it has finished analyzing the statement. If there are
      * some extra characters on the line then throws syntax error exception.
-     * Otherwise it simply steps the lexical analyzer iterator over the EOL
-     * symbol.
+     * Otherwise it simply steps the lexical analyzer iterator over the symbol.
      *
      * @throws AnalysisException when there are extra character on the actual line
      */
-    protected void consumeEndOfLine() throws AnalysisException {
+    protected void consumeEndOfStatement() throws AnalysisException {
         final var le = ctx.lexicalAnalyzer.get();
-        if (le != null && !le.isLineTerminator()) {
+        if (le != null && !(le.isLineTerminator() || le.isStatementSeparator())) {
             SyntaxExceptionUtility.throwSyntaxException(
                     "There are extra characters following the expression after the '"
                             + getName() + "' keyword", le);

--- a/src/main/java/com/scriptbasic/syntax/commands/AbstractCommandAnalyzerGlobalLocal.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/AbstractCommandAnalyzerGlobalLocal.java
@@ -27,7 +27,7 @@ public abstract class AbstractCommandAnalyzerGlobalLocal extends AbstractCommand
         final var node = newNode();
         final var list = analyzeSimpleLeftValueList();
         node.setLeftValueList(list);
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return node;
     }
 

--- a/src/main/java/com/scriptbasic/syntax/commands/AbstractCommandAnalyzerIfKind.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/AbstractCommandAnalyzerIfKind.java
@@ -31,7 +31,7 @@ public abstract class AbstractCommandAnalyzerIfKind extends
     protected Expression analizeLine() throws AnalysisException {
         final var condition = analyzeExpression();
         assertKeyWord(ScriptBasicKeyWords.KEYWORD_THEN);
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return condition;
     }
 

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerCall.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerCall.java
@@ -26,7 +26,7 @@ public class CommandAnalyzerCall extends AbstractCommandAnalyzer {
             ctx.lexicalAnalyzer.resetLine();
             final var commandLet = new CommandLet();
             commandLet.setExpression(ctx.expressionAnalyzer.analyze());
-            consumeEndOfLine();
+            consumeEndOfStatement();
             return commandLet;
         } else {
             final var functionName = lv.getIdentifier();
@@ -47,7 +47,7 @@ public class CommandAnalyzerCall extends AbstractCommandAnalyzer {
             if (needClosingParenthesis) {
                 consumeClosingParenthesis(ctx.lexicalAnalyzer);
             }
-            consumeEndOfLine();
+            consumeEndOfStatement();
             return new CommandCall(functionCall);
         }
     }

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerCase.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerCase.java
@@ -27,7 +27,7 @@ public class CommandAnalyzerCase
         } else {
             analyzeCaseConditions(node);
         }
-        consumeEndOfLine();
+        consumeEndOfStatement();
 
         var lastSelectPart = ctx.nestedStructureHouseKeeper.pop(AbstractCommandSelectPart.class);
         CommandSelect commandSelect = null;

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerDSL.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerDSL.java
@@ -86,7 +86,7 @@ public class CommandAnalyzerDSL extends AbstractCommandAnalyzer {
         if (!functionNameLexicalElement.isIdentifier()) {
             throw new BasicSyntaxException("there should be a function name after the keyword 'call' defining a sentenceó");
         }
-        consumeEndOfLine();
+        consumeEndOfStatement();
         final String[] syntaxElements = sentence.split("\\s+");
         if (syntaxElements.length == 0) {
             throw new BasicSyntaxException("sentence can not be empty");

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerElse.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerElse.java
@@ -14,7 +14,7 @@ public class CommandAnalyzerElse extends AbstractCommandAnalyzerIfElseKind {
     @Override
     public Command analyze() throws AnalysisException {
         final var node = new CommandElse();
-        consumeEndOfLine();
+        consumeEndOfStatement();
         registerAndSwapNode(node);
         return node;
     }

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerEnd.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerEnd.java
@@ -25,7 +25,7 @@ public class CommandAnalyzerEnd extends AbstractCommandAnalyzer {
             throw new BasicSyntaxException(
                     "Select has to be terminated with End Select statement");        	
         }
-        consumeEndOfLine();
+        consumeEndOfStatement();
         
         var lastSelectPart = ctx.nestedStructureHouseKeeper.pop(AbstractCommandSelectPart.class);
 

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerEndIf.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerEndIf.java
@@ -14,7 +14,7 @@ public class CommandAnalyzerEndIf extends AbstractCommandAnalyzerIfElseKind {
     @Override
     public Command analyze() throws AnalysisException {
         final var node = new CommandEndIf();
-        consumeEndOfLine();
+        consumeEndOfStatement();
         registerAndPopNode(node);
         return node;
     }

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerEndSub.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerEndSub.java
@@ -15,7 +15,7 @@ public class CommandAnalyzerEndSub extends AbstractCommandAnalyzer {
     @Override
     public Command analyze() throws AnalysisException {
         final var node = new CommandEndSub();
-        consumeEndOfLine();
+        consumeEndOfStatement();
         final var commandSub = ctx.nestedStructureHouseKeeper.pop(CommandSub.class);
         commandSub.setCommandEndSub(node);
         return node;

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerFor.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerFor.java
@@ -31,7 +31,7 @@ public class CommandAnalyzerFor extends AbstractCommandAnalyzer {
             node.setLoopStepValue(null);
         }
         pushNode(node);
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return node;
     }
 

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerLet.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerLet.java
@@ -27,7 +27,7 @@ public class CommandAnalyzerLet extends AbstractCommandAnalyzer {
                     lexicalElement, null);
         }
         commandLet.setExpression(ctx.expressionAnalyzer.analyze());
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return commandLet;
     }
 

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerMethod.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerMethod.java
@@ -62,7 +62,7 @@ public class CommandAnalyzerMethod extends AbstractCommandAnalyzer {
         node.setKlass(KlassUtility.forNameEx(className));
         node.setMethodName(methodName);
         node.setAlias(alias);
-        consumeEndOfLine();
+        consumeEndOfStatement();
 
         return node;
     }

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerNext.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerNext.java
@@ -35,7 +35,7 @@ public class CommandAnalyzerNext extends AbstractCommandAnalyzer {
                         lexicalElement);
             }
         }
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return node;
     }
 }

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerPrint.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerPrint.java
@@ -24,7 +24,7 @@ public class CommandAnalyzerPrint extends AbstractCommandAnalyzer {
         final var node = new CommandPrint();
         final var expressionList = analyzeExpressionList();
         node.setExpressionList(expressionList);
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return node;
     }
 

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerReturn.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerReturn.java
@@ -29,7 +29,7 @@ public class CommandAnalyzerReturn extends AbstractCommandAnalyzer {
         } else {
             node.setReturnExpression(null);
         }
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return node;
     }
 

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerSelect.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerSelect.java
@@ -23,7 +23,7 @@ public class CommandAnalyzerSelect
             ctx.lexicalAnalyzer.get();
         // read expression till end of line
         final var expression = analyzeExpression();
-        consumeEndOfLine();
+        consumeEndOfStatement();
 
         final var node = new CommandSelect();
         node.setExpression(expression);

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerSub.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerSub.java
@@ -37,7 +37,7 @@ public class CommandAnalyzerSub extends AbstractCommandAnalyzer {
             node.setArguments(null);
         }
         pushNode(node);
-        consumeEndOfLine();
+        consumeEndOfStatement();
         return node;
     }
 }

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerUse.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerUse.java
@@ -39,7 +39,7 @@ public class CommandAnalyzerUse extends AbstractCommandAnalyzer {
         } else {
             aliasName = className;
         }
-        consumeEndOfLine();
+        consumeEndOfStatement();
         if (className.indexOf('.') != -1 || aliasName.indexOf('.') != -1) {
             throw new BasicSyntaxException(
                     "class name and alias name should not contain dot in command USE");

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerWend.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerWend.java
@@ -15,7 +15,7 @@ public class CommandAnalyzerWend extends AbstractCommandAnalyzer {
     @Override
     public Command analyze() throws AnalysisException {
         final var node = new CommandWend();
-        consumeEndOfLine();
+        consumeEndOfStatement();
         final var commandWhile = ctx.nestedStructureHouseKeeper.pop(CommandWhile.class);
         node.setCommandWhile(commandWhile);
         commandWhile.setWendNode(node);

--- a/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerWhile.java
+++ b/src/main/java/com/scriptbasic/syntax/commands/CommandAnalyzerWhile.java
@@ -15,7 +15,7 @@ public class CommandAnalyzerWhile extends AbstractCommandAnalyzer {
     public Command analyze() throws AnalysisException {
         final var node = new CommandWhile();
         final var condition = analyzeExpression();
-        consumeEndOfLine();
+        consumeEndOfStatement();
         node.setCondition(condition);
         pushNode(node);
         return node;

--- a/src/test/java/com/scriptbasic/lexer/TestBasicLexicalAnalyzer.java
+++ b/src/test/java/com/scriptbasic/lexer/TestBasicLexicalAnalyzer.java
@@ -97,22 +97,23 @@ public class TestBasicLexicalAnalyzer {
 
     @Test
     public void newLineIsAnalyzedAs_surprise_surprise_newLine() throws AnalysisException {
-        assertLexicals(from("\n"), SYMBOL("\n")
-        );
+        assertLexicals(from("\n"), SYMBOL("\n"));
+    }
+
+    @Test
+    public void colonIsAnalyzedAs_statementSeparator() throws AnalysisException {
+        assertLexicals(from(":"), SYMBOL(":"));
     }
 
     @Test
     public void integerNumbersAreAnalyzedNicely() throws AnalysisException {
-        assertLexicals(from("12"), LONG("12")
-        );
+        assertLexicals(from("12"), LONG("12"));
     }
 
     @Test
     public void floatingNumbersAreAnalyzedNicely() throws AnalysisException {
-        assertLexicals(from("13e3"), DOUBLE("13e3")
-        );
-        assertLexicals(from("13.8"), DOUBLE("13.8")
-        );
+        assertLexicals(from("13e3"), DOUBLE("13e3"));
+        assertLexicals(from("13.8"), DOUBLE("13.8"));
         assertLexicals(from("13.8e2"), DOUBLE("13.8e2"));
         assertLexicals(from("13.8e+2"), DOUBLE("13.8e+2"));
         assertLexicals(from("13.8e-2"), DOUBLE("13.8e-2"));

--- a/src/test/java/com/scriptbasic/syntax/NullLexicalElement.java
+++ b/src/test/java/com/scriptbasic/syntax/NullLexicalElement.java
@@ -97,4 +97,9 @@ public class NullLexicalElement implements LexicalElement {
     public int getPosition() {
         return 0;
     }
+
+    @Override
+    public Boolean isStatementSeparator() {
+        return null;
+    }
 }

--- a/src/test/java/com/scriptbasic/testprograms/TestPrograms.java
+++ b/src/test/java/com/scriptbasic/testprograms/TestPrograms.java
@@ -68,6 +68,7 @@ public class TestPrograms {
         testSyntaxFail("TestSelectBadSyntax2.bas");
         testSyntaxFail("TestSelectBadSyntax3.bas");
         testSyntaxFail("TestSelectBadSyntax4.bas");
+        codeTest("TestSingleLine.bas", "12345678910");
         codeTest("TestBooleanConversions.bas", "111111");
         codeTest("TestArrays.bas", "OK");
         try {

--- a/src/test/resources/com/scriptbasic/testprograms/TestSingleLine.bas
+++ b/src/test/resources/com/scriptbasic/testprograms/TestSingleLine.bas
@@ -1,0 +1,8 @@
+'
+' This program is used to test multiple statements on one line
+'
+print "1": print "2"
+print "3":print "4"
+print "5" :print "6"
+print "7" : print "8"
+let v=9 : print v : print v+1


### PR DESCRIPTION
Rename consumeEndOfLine to consumeEndOfStatement and allow to use colon as a statement separator. This patch also allows to add support for single line statement (if .... then ... [else ...]) as a separate feature.