### PR TITLE
Function calls are case insensitive (e.g. might call: Left, left, LEFT)

### DIFF
--- a/src/main/java/com/scriptbasic/executors/BasicMethodRegistry.java
+++ b/src/main/java/com/scriptbasic/executors/BasicMethodRegistry.java
@@ -135,12 +135,13 @@ public class BasicMethodRegistry implements MethodRegistry {
     public void registerJavaMethod(final String alias, final Class<?> klass,
                                    final String methodName, final Class<?>[] argumentTypes)
             throws BasicRuntimeException {
+        final var aliasLowerCase = alias.toLowerCase();
         final var item = new RegistryItem();
         item.methodName = methodName;
         item.klass = klass;
         item.args = argumentTypes.clone();
-        registry.put(formKey(alias, klass), item);
-        registerGlobal(alias, item);
+        registry.put(formKey(aliasLowerCase, klass), item);
+        registerGlobal(aliasLowerCase, item);
     }
 
     private static class RegistryItem {

--- a/src/main/java/com/scriptbasic/executors/rightvalues/FunctionCall.java
+++ b/src/main/java/com/scriptbasic/executors/rightvalues/FunctionCall.java
@@ -46,7 +46,7 @@ public class FunctionCall extends AbstractIdentifieredExpressionListedExpression
     private RightValue callJavaFunction(final Interpreter interpreter)
             throws ScriptBasicException {
         final RightValue result;
-        final var functionName = getVariableName();
+        final var functionName = getVariableName().toLowerCase();
         final List<RightValue> args = ExpressionUtility.evaluateExpressionList(
                 interpreter, getExpressionList());
         final var method = interpreter.getJavaMethod(null, functionName);

--- a/src/test/resources/com/scriptbasic/testprograms/TestStringFunctions.bas
+++ b/src/test/resources/com/scriptbasic/testprograms/TestStringFunctions.bas
@@ -1,4 +1,4 @@
 v = "0123456789"
 PRINT left(v,2)
-PRINT right(v,2)
-PRINT mid(v,2,3)
+PRINT RIGHT(v,2)
+PRINT Mid(v,2,3)


### PR DESCRIPTION
Function names and keywords are case insensitive in Basic. Keywords are already case insensitive (PRINT, print...). This patch implements same behaviour for functions.