### PR TITLE
AbstractNumericRightValue can be parametrized with different inner type

### DIFF
--- a/src/main/java/com/scriptbasic/executors/operators/AbstractBinaryFullCircuitNumericOperator.java
+++ b/src/main/java/com/scriptbasic/executors/operators/AbstractBinaryFullCircuitNumericOperator.java
@@ -39,8 +39,8 @@ public abstract class AbstractBinaryFullCircuitNumericOperator<T extends Number>
                     "Can not execute the operation on undefined value.");
         }
         if (leftOperand.isNumeric() && rightOperand.isNumeric()) {
-            a = ((AbstractNumericRightValue<Number>) leftOperand).getValue();
-            b = ((AbstractNumericRightValue<Number>) rightOperand).getValue();
+            a = ((AbstractNumericRightValue<Number, Object>) leftOperand).getNumericValue();
+            b = ((AbstractNumericRightValue<Number, Object>) rightOperand).getNumericValue();
             if (leftOperand.isDouble()) {
                 if (rightOperand.isDouble()) {
                     result = operateOnDoubleDouble((Double) a, (Double) b);

--- a/src/main/java/com/scriptbasic/executors/rightvalues/AbstractNumericRightValue.java
+++ b/src/main/java/com/scriptbasic/executors/rightvalues/AbstractNumericRightValue.java
@@ -1,5 +1,13 @@
 package com.scriptbasic.executors.rightvalues;
 
-public abstract class AbstractNumericRightValue<T extends Number> extends
+public abstract class AbstractNumericRightValue<N extends Number, T> extends
         AbstractPrimitiveRightValue<T> {
+
+    /**
+     * Return numeric value representing this right value
+     * 
+     * @return numeric value
+     */
+    public abstract N getNumericValue();
+
 }

--- a/src/main/java/com/scriptbasic/executors/rightvalues/BasicBooleanValue.java
+++ b/src/main/java/com/scriptbasic/executors/rightvalues/BasicBooleanValue.java
@@ -9,7 +9,7 @@ public final class BasicBooleanValue extends AbstractPrimitiveRightValue<Boolean
     }
 
     private static Boolean convertNumeric(
-            final AbstractNumericRightValue<Number> originalValue) {
+            final AbstractNumericRightValue<Number, Object> originalValue) {
         final Boolean convertedValue;
         if (originalValue.isLong()) {
             final var l = (Long) originalValue.getValue();

--- a/src/main/java/com/scriptbasic/executors/rightvalues/BasicDoubleValue.java
+++ b/src/main/java/com/scriptbasic/executors/rightvalues/BasicDoubleValue.java
@@ -3,7 +3,7 @@ package com.scriptbasic.executors.rightvalues;
 import com.scriptbasic.interfaces.BasicRuntimeException;
 import com.scriptbasic.spi.RightValue;
 
-public class BasicDoubleValue extends AbstractNumericRightValue<Double> {
+public class BasicDoubleValue extends AbstractNumericRightValue<Double, Double> {
 
     public BasicDoubleValue(final Double d) {
         setValue(d);
@@ -58,5 +58,10 @@ public class BasicDoubleValue extends AbstractNumericRightValue<Double> {
         } catch (final BasicRuntimeException e) {
             return super.toString();
         }
+    }
+
+    @Override
+    public Double getNumericValue() {
+        return getValue();
     }
 }

--- a/src/main/java/com/scriptbasic/executors/rightvalues/BasicLongValue.java
+++ b/src/main/java/com/scriptbasic/executors/rightvalues/BasicLongValue.java
@@ -3,7 +3,7 @@ package com.scriptbasic.executors.rightvalues;
 import com.scriptbasic.interfaces.BasicRuntimeException;
 import com.scriptbasic.spi.RightValue;
 
-public class BasicLongValue extends AbstractNumericRightValue<Long> {
+public class BasicLongValue extends AbstractNumericRightValue<Long, Long> {
 
     public BasicLongValue(final Long i) {
         setValue(i);
@@ -54,5 +54,10 @@ public class BasicLongValue extends AbstractNumericRightValue<Long> {
         } catch (final BasicRuntimeException e) {
             return super.toString();
         }
+    }
+
+    @Override
+    public Long getNumericValue() {
+        return getValue();
     }
 }

--- a/src/main/java/com/scriptbasic/utility/RightValueUtility.java
+++ b/src/main/java/com/scriptbasic/utility/RightValueUtility.java
@@ -37,7 +37,7 @@ public final class RightValueUtility {
     public static Integer convert2Integer(final RightValue index)
             throws ScriptBasicException {
         if (index.isNumeric()) {
-            return ((AbstractNumericRightValue<Number>) index).getValue().intValue();
+            return ((AbstractNumericRightValue<Number, Object>) index).getNumericValue().intValue();
         } else {
             throw new BasicRuntimeException(
                     index.toString()


### PR DESCRIPTION
This change allows to implement RightValues compatible with Numeric but with other real class then Numeric. Example of such RightValues are LocalDate or EmptyValue. Real implementations based on this patch are in my branches empty_value and support_for_date2.

AbstractNumericRightValue can be parametrized with different inner type then Numeric based. New abstract method getNumericValue allows to get Numeric value.

Example of usage:
public class BasicDateValue extends AbstractNumericRightValue<Long, LocalDate> {
...
}
public class BasicEmptyValue extends AbstractNumericRightValue<Long, EmptyValue> {
}
